### PR TITLE
Replace iOS 8 API to avoid crash

### DIFF
--- a/Classes/LinphoneManager.m
+++ b/Classes/LinphoneManager.m
@@ -1780,7 +1780,7 @@ static int comp_call_state_paused(const LinphoneCall *call, const void *param) {
 	OSStatus lStatus = AudioSessionGetProperty(kAudioSessionProperty_AudioRoute, &lNewRouteSize, &lNewRoute);
 	if (!lStatus && lNewRouteSize > 0) {
 		NSString *route = (__bridge NSString *)lNewRoute;
-		allow = ![route containsString:@"Heads"] && ![route isEqualToString:@"Lineout"];
+		allow = [route rangeOfString:@"Heads"].location == NSNotFound && ![route isEqualToString:@"Lineout"];
 		CFRelease(lNewRoute);
 	}
 	return allow;


### PR DESCRIPTION
One line of changes which replaced the iOS 8 API to avoid crash on old iOS, as the app supports iOS 6 and above.