### PR TITLE
Resolve critical bug AppCrash in Russian version (A lot of dislikes in AppStore)

### DIFF
--- a/Classes/HistoryDetailsTableView.m
+++ b/Classes/HistoryDetailsTableView.m
@@ -84,7 +84,7 @@
 	time_t callTime = linphone_call_log_get_start_date(log);
 	cell.textLabel.textAlignment = NSTextAlignmentCenter;
 	[cell.textLabel
-		setText:[NSString stringWithFormat:@"%@ - %@",
+		setText:[NSString stringWithFormat:@"%@ (%@)",
 										   [LinphoneUtils timeToString:callTime withFormat:LinphoneDateHistoryDetails],
 										   [LinphoneUtils durationToString:duration]]];
 	BOOL outgoing = (linphone_call_log_get_dir(log) == LinphoneCallOutgoing);

--- a/Classes/Utils/Log.m
+++ b/Classes/Utils/Log.m
@@ -63,7 +63,7 @@
 }
 
 + (void)directLog:(OrtpLogLevel)level text:(NSString *)text {
-	bctbx_log(BCTBX_LOG_DOMAIN, level, "%s", text.cString);
+	bctbx_log(BCTBX_LOG_DOMAIN, level, "%s", [text cStringUsingEncoding:NSUTF8StringEncoding]);
 }
 
 #pragma mark - Logs Functions callbacks


### PR DESCRIPTION
1. "Classes/Utils/Log.m"
Resolve critical bug with calling (app crashes when you try to call from Russian Locale with Cyrillic symbols in date time). In Russian page of LinPhone you can found a lot of negative messages about this problem.
![image](https://user-images.githubusercontent.com/32325196/97121664-22d2aa80-1731-11eb-8abe-e9f1c2387926.png)

2. "Classes/HistoryDetailsTableView.m"
Little change with date and duration in historytableview format (From "date at time - duration" to "date at time (duration) to separate time and duration")

_p.s. Also improve Russian translates in Transifex, (Resolve bag with historytableview format for stringformatter)_ 