### PR TITLE
Fix visualization for recordings in other languages.

### DIFF
--- a/Classes/AppManager.swift
+++ b/Classes/AppManager.swift
@@ -49,6 +49,8 @@ enum NetworkType: Int {
 		filePath = filePath.appending(address.isEmpty ? "unknow" : address)
 		let now = Date()
 		let dateFormat = DateFormatter()
+        // Force en_US translation.
+        dateFormat.locale = Locale(identifier: "en_US")
 		dateFormat.dateFormat = "E-d-MMM-yyyy-HH-mm-ss"
 		let date = dateFormat.string(from: now)
 		

--- a/Classes/RecordingsListTableView.m
+++ b/Classes/RecordingsListTableView.m
@@ -81,13 +81,10 @@
         if (![file hasPrefix:@"recording_"]) {
             continue;
         }
+        
         NSArray *parsedName = [LinphoneUtils parseRecordingName:file];
         NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
         [dateFormat setDateFormat:@"EEEE, MMM d, yyyy"];
-		if ([parsedName count] < 2) {
-			LOGW(@"Can not parse this recoding file: %@", file);
-			continue;
-		}
         NSString *dayPretty = [dateFormat stringFromDate:[parsedName objectAtIndex:1]];
         NSMutableArray *recOfDay = [recordings objectForKey:dayPretty];
         if (recOfDay) {
@@ -106,7 +103,6 @@
             [recordings setObject:recOfDay forKey:dayPretty];
         }
     }
-    
     
     LOGI(@"====>>>> Load recording list - End");
     [super loadData];

--- a/Classes/Utils/Utils.m
+++ b/Classes/Utils/Utils.m
@@ -509,6 +509,8 @@
     //splitString: first element is the 'recording' prefix, last element is the date with the "E-d-MMM-yyyy-HH-mm-ss" format.
     NSString *name = [[splitString subarrayWithRange:NSMakeRange(1, [splitString count] -2)] componentsJoinedByString:@""];
     NSDateFormatter *format = [[NSDateFormatter alloc] init];
+    // Force en_US translation.
+    format.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
     [format setDateFormat:@"E-d-MMM-yyyy-HH-mm-ss"];
     NSString *dateWithMkv = [splitString objectAtIndex:[splitString count]-1]; //this will be in the form "E-d-MMM-yyyy-HH-mm-ss.mkv", we have to delete the extension
     NSDate *date = [format dateFromString:[dateWithMkv substringToIndex:[dateWithMkv length] - 4]];


### PR DESCRIPTION
Now, if user record a call in a language, the file saved in file system has a name in that language. Changing the language, the recording is not shown because formatter can't understand the file name.

With this fix, the file name is in en_US locale in any case and is read in that locale in any case, so every recording is shown in the list view.

This problem is resolved in our fork of the project with those lines of code. There's no issues in list view headers views and the reproduction of the audio files has no issues.