### PR TITLE
Respect bottom safe area on modern iPhones

### DIFF
--- a/Classes/LinphoneUI/Base.lproj/TabBarView.xib
+++ b/Classes/LinphoneUI/Base.lproj/TabBarView.xib
@@ -27,10 +27,6 @@
             <rect key="frame" x="0.0" y="0.0" width="360" height="66"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
-                <imageView userInteractionEnabled="NO" tag="1" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="color_C.png" id="svE-vh-ct2" userLabel="backgroundImage">
-                    <frame key="frameInset" minX="0.0%" minY="0.0%" width="100.00%" height="100.00%"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
-                </imageView>
                 <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" id="6" userLabel="historyButton" customClass="UIIconButton">
                     <frame key="frameInset" minX="0.0%" minY="0.0%" width="25.00%" height="100.00%"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
@@ -127,6 +123,7 @@
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
             </subviews>
+            <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="226" y="-36"/>
@@ -135,10 +132,6 @@
             <rect key="frame" x="0.0" y="0.0" width="90" height="333"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
             <subviews>
-                <imageView userInteractionEnabled="NO" tag="1" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="color_C.png" id="V07-hP-Heu" userLabel="backgroundImage">
-                    <frame key="frameInset" minX="0.0%" minY="0.0%" width="100.00%" height="100.00%"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
-                </imageView>
                 <button opaque="NO" tag="2" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" id="hlj-lf-AGD" userLabel="historyButton" customClass="UIIconButton">
                     <frame key="frameInset" minX="0.0%" minY="0.0%" width="100.00%" height="24.93%"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
@@ -235,6 +228,7 @@
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
             </subviews>
+            <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="526" y="86.5"/>

--- a/Classes/LinphoneUI/UICompositeView.m
+++ b/Classes/LinphoneUI/UICompositeView.m
@@ -155,6 +155,7 @@
 	customView.frame = self.view.frame;
 	customView.tag = 999;
 	[self.view addSubview:customView];
+    self.view.backgroundColor = [UIColor darkGrayColor];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -605,7 +606,7 @@
 	if (self.tabBarViewController != nil && currentViewDescription.tabBarEnabled) {
 		tabFrame.origin.x = 0;
 		if (UIInterfaceOrientationIsPortrait([self currentOrientation])) {
-			tabFrame.origin.y = viewFrame.size.height - tabFrame.size.height;
+			tabFrame.origin.y = viewFrame.size.height - tabFrame.size.height - self.view.safeAreaInsets.bottom;
 		} else {
 			tabFrame.origin.y = origin;
 			tabFrame.size.height = viewFrame.size.height - tabFrame.origin.y;


### PR DESCRIPTION
Hi there, 
this is a small fix that changes the apps layout to respect the bottom safe area on modern iPhones with rounded edges.
In addition, I removed the tab bars background images and assigned a background color that matches the background color of the parent view.